### PR TITLE
Rename unpacker to codec and implement LazyCodec

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
 permissions:
   contents: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   test:
     name: Test

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     services:
       rustfs:
         image: rustfs/rustfs:latest

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -42,7 +42,7 @@ To this end, we repeatedly read random locations in the matrix and measure the t
 ```py
 @timeit
 def read_msg(file: str):
-    with LazyReader(file, unpacker=MsgspecUnpacker, cached=False) as reader:
+    with LazyReader(file, unpacker=MsgspecCodec, cached=False) as reader:
         for _ in range(repeat):
             reader[random.randint(0, 4999)][random.randint(0, 4999)]
 
@@ -52,7 +52,7 @@ def read_h5(file: str):
     with h5py.File(file, "r") as f:
         dataset = f["data"]
         for _ in range(repeat):
-            dataset[random.randint(0, 4999)][random.randint(0, 4999)]`
+            dataset[random.randint(0, 4999)][random.randint(0, 4999)]
 ```
 
 The following is the result of reading 1000 elements.

--- a/docs/example.md
+++ b/docs/example.md
@@ -113,7 +113,7 @@ from msglc.reader import LazyReader
 dump("data.msg", {"a": [1, 2, 3]})
 
 with LazyReader("data.msg") as reader:
-    msgpack_raw = reader.msgpack_raw_data(chunked=False)
+    msgpack_raw = reader.protocol_raw_data(chunked=False)
     # this can be unpacked by any standard msgpack decoder
     # this prints: {'a': [1, 2, 3]}
     print(unpackb(msgpack_raw))

--- a/src/msglc/codec.py
+++ b/src/msglc/codec.py
@@ -15,6 +15,7 @@
 
 from abc import ABC, abstractmethod
 from importlib.util import find_spec
+from io import BytesIO
 
 import msgpack
 
@@ -27,6 +28,10 @@ class LazyCodec(ABC):
     @abstractmethod
     def decode(self, data):
         raise NotImplementedError
+
+    @staticmethod
+    def stream_decode(data):
+        yield from msgpack.Unpacker(BytesIO(data))
 
 
 class MsgpackCodec(LazyCodec):

--- a/src/msglc/codec.py
+++ b/src/msglc/codec.py
@@ -15,6 +15,7 @@
 
 from abc import ABC, abstractmethod
 from importlib.util import find_spec
+from inspect import isclass
 from io import BytesIO
 
 import msgpack
@@ -84,3 +85,16 @@ if find_spec("ormsgpack"):
             yield from msgpack.Unpacker(BytesIO(data))
 else:
     OrmsgpackCodec = MsgpackCodec
+
+
+def acquire_codec(codec: type[LazyCodec] | LazyCodec | None) -> LazyCodec:
+    if isinstance(codec, LazyCodec):
+        return codec
+
+    if isclass(codec) and issubclass(codec, LazyCodec):
+        return codec()
+
+    if codec is None:
+        return MsgspecCodec()
+
+    raise TypeError("Need a valid codec.")

--- a/src/msglc/codec.py
+++ b/src/msglc/codec.py
@@ -21,13 +21,21 @@ import msgpack
 
 class LazyCodec(ABC):
     @abstractmethod
+    def encode(self, data):
+        raise NotImplementedError
+
+    @abstractmethod
     def decode(self, data):
         raise NotImplementedError
 
 
 class MsgpackCodec(LazyCodec):
     def __init__(self):
+        self._packer = msgpack.Packer()
         self._unpacker = msgpack.Unpacker()
+
+    def encode(self, data):
+        return self._packer.pack(data)
 
     def decode(self, data):
         self._unpacker.feed(data)
@@ -39,7 +47,11 @@ if find_spec("msgspec"):
 
     class MsgspecCodec(LazyCodec):
         def __init__(self):
+            self._packer = msgspec.msgpack.Encoder()
             self._unpacker = msgspec.msgpack.Decoder()
+
+        def encode(self, data):
+            return self._packer.encode(data)
 
         def decode(self, data):
             return self._unpacker.decode(data)
@@ -51,6 +63,9 @@ if find_spec("ormsgpack"):
     import ormsgpack
 
     class OrmsgpackCodec(LazyCodec):
+        def encode(self, data):
+            return ormsgpack.packb(data)
+
         def decode(self, data):
             return ormsgpack.unpackb(data)
 else:

--- a/src/msglc/codec.py
+++ b/src/msglc/codec.py
@@ -19,13 +19,13 @@ from importlib.util import find_spec
 import msgpack
 
 
-class Unpacker(ABC):
+class LazyCodec(ABC):
     @abstractmethod
     def decode(self, data):
         raise NotImplementedError
 
 
-class MsgpackUnpacker(Unpacker):
+class MsgpackCodec(LazyCodec):
     def __init__(self):
         self._unpacker = msgpack.Unpacker()
 
@@ -37,21 +37,21 @@ class MsgpackUnpacker(Unpacker):
 if find_spec("msgspec"):
     import msgspec
 
-    class MsgspecUnpacker(Unpacker):
+    class MsgspecCodec(LazyCodec):
         def __init__(self):
             self._unpacker = msgspec.msgpack.Decoder()
 
         def decode(self, data):
             return self._unpacker.decode(data)
 else:
-    MsgspecUnpacker = MsgpackUnpacker
+    MsgspecCodec = MsgpackCodec
 
 
 if find_spec("ormsgpack"):
     import ormsgpack
 
-    class OrmsgpackUnpacker(Unpacker):
+    class OrmsgpackCodec(LazyCodec):
         def decode(self, data):
             return ormsgpack.unpackb(data)
 else:
-    OrmsgpackUnpacker = MsgpackUnpacker
+    OrmsgpackCodec = MsgpackCodec

--- a/src/msglc/codec.py
+++ b/src/msglc/codec.py
@@ -29,9 +29,9 @@ class LazyCodec(ABC):
     def decode(self, data):
         raise NotImplementedError
 
-    @staticmethod
-    def stream_decode(data):
-        yield from msgpack.Unpacker(BytesIO(data))
+    @abstractmethod
+    def stream_decode(self, data):
+        raise NotImplementedError
 
 
 class MsgpackCodec(LazyCodec):
@@ -45,6 +45,9 @@ class MsgpackCodec(LazyCodec):
     def decode(self, data):
         self._unpacker.feed(data)
         return self._unpacker.unpack()
+
+    def stream_decode(self, data):
+        yield from msgpack.Unpacker(BytesIO(data))
 
 
 if find_spec("msgspec"):
@@ -60,6 +63,9 @@ if find_spec("msgspec"):
 
         def decode(self, data):
             return self._unpacker.decode(data)
+
+        def stream_decode(self, data):
+            yield from msgpack.Unpacker(BytesIO(data))
 else:
     MsgspecCodec = MsgpackCodec
 
@@ -73,5 +79,8 @@ if find_spec("ormsgpack"):
 
         def decode(self, data):
             return ormsgpack.unpackb(data)
+
+        def stream_decode(self, data):
+            yield from msgpack.Unpacker(BytesIO(data))
 else:
     OrmsgpackCodec = MsgpackCodec

--- a/src/msglc/reader.py
+++ b/src/msglc/reader.py
@@ -18,14 +18,13 @@ from __future__ import annotations
 import asyncio
 import pickle
 from dataclasses import dataclass
-from inspect import isclass
 from typing import TYPE_CHECKING, Any
 
 from bitarray import bitarray
 from fsspec.implementations.local import LocalFileSystem
 from upath import UPath
 
-from .codec import LazyCodec, MsgspecCodec
+from .codec import LazyCodec, acquire_codec
 from .config import (
     BufferReaderType,
     config,
@@ -103,15 +102,7 @@ class LazyItem:
         self._offset: int = offset  # start of original data
         self._counter: LazyStats | None = counter
         self._cached: bool = cached
-        self._unpacker: LazyCodec
-        if isinstance(unpacker, LazyCodec):
-            self._unpacker = unpacker
-        elif isclass(unpacker) and issubclass(unpacker, LazyCodec):
-            self._unpacker = unpacker()
-        elif unpacker is None:
-            self._unpacker = MsgspecCodec()
-        else:
-            raise TypeError("Need a valid unpacker.")
+        self._unpacker: LazyCodec = acquire_codec(unpacker)
 
         self._accessed_items: int = 0
 

--- a/src/msglc/reader.py
+++ b/src/msglc/reader.py
@@ -19,10 +19,8 @@ import asyncio
 import pickle
 from dataclasses import dataclass
 from inspect import isclass
-from io import BytesIO
 from typing import TYPE_CHECKING, Any
 
-import msgpack
 from bitarray import bitarray
 from fsspec.implementations.local import LocalFileSystem
 from upath import UPath
@@ -285,7 +283,7 @@ class LazyList(LazyItem):
                 low = mid
 
     def _all(self, start: int, end: int) -> list:
-        return list(msgpack.Unpacker(BytesIO(self._readb(start, end))))
+        return list(self._unpacker.stream_decode(self._readb(start, end)))
 
     def __getitem__(self, index):
         index_range: list | range

--- a/src/msglc/reader.py
+++ b/src/msglc/reader.py
@@ -27,6 +27,7 @@ from bitarray import bitarray
 from fsspec.implementations.local import LocalFileSystem
 from upath import UPath
 
+from .codec import LazyCodec, MsgspecCodec
 from .config import (
     BufferReaderType,
     config,
@@ -34,7 +35,6 @@ from .config import (
     increment_gc_counter,
 )
 from .index import normalise_index, to_index
-from .unpacker import MsgspecUnpacker, Unpacker
 from .writer import LazyWriter
 
 if TYPE_CHECKING:
@@ -99,19 +99,19 @@ class LazyItem:
         *,
         counter: LazyStats | None = None,
         cached: bool = True,
-        unpacker: Unpacker | None = None,
+        unpacker: LazyCodec | None = None,
     ):
         self._buffer: BufferReader = buffer
         self._offset: int = offset  # start of original data
         self._counter: LazyStats | None = counter
         self._cached: bool = cached
-        self._unpacker: Unpacker
-        if isinstance(unpacker, Unpacker):
+        self._unpacker: LazyCodec
+        if isinstance(unpacker, LazyCodec):
             self._unpacker = unpacker
-        elif isclass(unpacker) and issubclass(unpacker, Unpacker):
+        elif isclass(unpacker) and issubclass(unpacker, LazyCodec):
             self._unpacker = unpacker()
         elif unpacker is None:
-            self._unpacker = MsgspecUnpacker()
+            self._unpacker = MsgspecCodec()
         else:
             raise TypeError("Need a valid unpacker.")
 
@@ -242,7 +242,7 @@ class LazyList(LazyItem):
         *,
         counter: LazyStats | None = None,
         cached: bool = True,
-        unpacker: Unpacker | None = None,
+        unpacker: LazyCodec | None = None,
     ):
         super().__init__(
             buffer, offset, counter=counter, cached=cached, unpacker=unpacker
@@ -412,7 +412,7 @@ class LazyDict(LazyItem):
         *,
         counter: LazyStats | None = None,
         cached: bool = True,
-        unpacker: Unpacker | None = None,
+        unpacker: LazyCodec | None = None,
     ):
         super().__init__(
             buffer, offset, counter=counter, cached=cached, unpacker=unpacker
@@ -513,21 +513,24 @@ class LazyReader(LazyItem):
         *,
         counter: LazyStats | None = None,
         cached: bool = True,
-        unpacker: Unpacker | None = None,
+        unpacker: LazyCodec | None = None,
         fs: FileSystem | None = None,
     ):
         """
         It is possible to use a customized unpacker.
-        Please inherit the `Unpacker` class from the `unpacker.py`.
+        Please inherit the `LazyCodec` class from the `codec.py`.
         There are already several unpackers available using different libraries.
 
         ```py
-        class CustomUnpacker(Unpacker):
+        class CustomCodec(LazyCodec):
+            def encode(self, data: bytes):
+                # provide the encoding logic
+                ...
             def decode(self, data: bytes):
                 # provide the decoding logic
                 ...
 
-        with LazyReader("file.msg", unpacker=CustomUnpacker()) as reader:
+        with LazyReader("file.msg", unpacker=CustomCodec()) as reader:
             # read the data
             ...
         ```

--- a/src/msglc/reader.py
+++ b/src/msglc/reader.py
@@ -797,7 +797,7 @@ class LazyReader(LazyItem):
             self._raw_stats.data_size + self._raw_stats.toc_size,
         )
 
-    def msgpack_raw_data(self, chunked: bool = True):
+    def protocol_raw_data(self, chunked: bool = True):
         """
         Reads the msgpack data out as bytes.
         The data shall be fully compatible with the msgpack specification thus can be decoded by any msgpack decoders.

--- a/src/msglc/reader.py
+++ b/src/msglc/reader.py
@@ -97,7 +97,7 @@ class LazyItem:
         *,
         counter: LazyStats | None = None,
         cached: bool = True,
-        unpacker: LazyCodec | None = None,
+        unpacker: type[LazyCodec] | LazyCodec | None = None,
     ):
         self._buffer: BufferReader = buffer
         self._offset: int = offset  # start of original data
@@ -511,7 +511,7 @@ class LazyReader(LazyItem):
         *,
         counter: LazyStats | None = None,
         cached: bool = True,
-        unpacker: LazyCodec | None = None,
+        unpacker: type[LazyCodec] | LazyCodec | None = None,
         fs: FileSystem | None = None,
     ):
         """

--- a/src/msglc/toc.py
+++ b/src/msglc/toc.py
@@ -25,8 +25,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from tempfile import TemporaryFile
 
-    from msgpack import Packer
-
+    from .codec import LazyCodec
     from .config import BufferWriter
 
 try:
@@ -64,12 +63,12 @@ class TOC:
     def __init__(
         self,
         *,
-        packer: Packer,
+        packer: LazyCodec,
         buffer: BufferWriter | TemporaryFile,
         transform: Callable = None,
     ):
         self._buffer: BufferWriter | TemporaryFile = buffer
-        self._packer: Packer = packer
+        self._packer: LazyCodec = packer
         self._initial_pos = self._buffer.tell()
         self._pos: int = 0
         self._in_numpy_array: bool = False
@@ -110,7 +109,7 @@ class TOC:
 
         if not isinstance(obj, (Mapping, list, set, tuple, ndarray)):
             start_pos = self._pos
-            self._writeb(self._packer.pack(obj))
+            self._writeb(self._packer.encode(obj))
             return _generate(start_pos)
 
         current_level_is_numpy_array: bool = False
@@ -127,7 +126,7 @@ class TOC:
         elif ndarray is not list and isinstance(obj, ndarray):
             if config.numpy_encoder:
                 start_pos = self._pos
-                self._writeb(self._packer.pack(obj.dumps()))
+                self._writeb(self._packer.encode(obj.dumps()))
                 return _generate(start_pos)
 
             obj = obj.tolist()
@@ -143,7 +142,7 @@ class TOC:
             self._write_map_header(len(obj))
             obj_toc = {}
             for k, v in self._transform(obj.items()):
-                self._writeb(self._packer.pack(k))
+                self._writeb(self._packer.encode(k))
                 obj_toc[k] = self._pack(v)
             all_small_obj = all(v[2] for v in obj_toc.values())
         elif isinstance(obj, list):
@@ -160,7 +159,7 @@ class TOC:
                 list_start: int = self._pos
 
                 for v in obj:
-                    self._writeb(self._packer.pack(v))
+                    self._writeb(self._packer.encode(v))
 
                 if self._pos < start_pos + config.small_obj_optimization_threshold:
                     return _resume_flag(_generate(start_pos))

--- a/src/msglc/writer.py
+++ b/src/msglc/writer.py
@@ -16,13 +16,14 @@
 from __future__ import annotations
 
 import os.path
+from inspect import isclass
 from io import BufferedReader, BytesIO
 from tempfile import TemporaryFile
 from typing import TYPE_CHECKING
 
 from upath import UPath
 
-from .codec import LazyCodec, MsgpackCodec
+from .codec import LazyCodec, MsgspecCodec
 from .config import (
     config,
     decrement_gc_counter,
@@ -53,11 +54,20 @@ class LazyBuffer:
     def __init__(
         self,
         buffer_or_path: str | UPath | BufferWriter,
-        packer: LazyCodec | None,
+        packer: type[LazyCodec] | LazyCodec | None,
         fs: FileSystem | None,
     ):
         self._buffer_or_path: str | UPath | BufferWriter = buffer_or_path
-        self._packer: LazyCodec = packer or MsgpackCodec()
+        self._packer: LazyCodec
+        if isinstance(packer, LazyCodec):
+            self._packer = packer
+        elif isclass(packer) and issubclass(packer, LazyCodec):
+            self._packer = packer()
+        elif packer is None:
+            self._packer = MsgspecCodec()
+        else:
+            raise TypeError("Need a valid packer.")
+
         self._fs: FileSystem | None = fs or config.fs
 
         self._buffer: BufferWriter | TemporaryFile = None  # type: ignore
@@ -87,7 +97,7 @@ class LazyWriter(LazyBuffer):
         self,
         buffer_or_path: str | UPath | BufferWriter,
         *,
-        packer: LazyCodec | None = None,
+        packer: type[LazyCodec] | LazyCodec | None = None,
         fs: FileSystem | None = None,
         toc_cls: type[TOC] | None = None,
     ):
@@ -192,7 +202,7 @@ class LazyCombiner(LazyBuffer):
         buffer_or_path: str | UPath | BufferWriter,
         *,
         mode: Literal["a", "w"] = "w",
-        packer: LazyCodec | None = None,
+        packer: type[LazyCodec] | LazyCodec | None = None,
         fs: FileSystem | None = None,
     ):
         """

--- a/src/msglc/writer.py
+++ b/src/msglc/writer.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from .config import BufferReader, BufferWriter, FileSystem
 
 
-def _upsert(source: BufferReader, target: str, fs: FileSystem | None):
+def _upsert(source: BufferReader | TemporaryFile, target: str, fs: FileSystem | None):  # type: ignore
     if not fs:
         return
 
@@ -50,15 +50,23 @@ def _upsert(source: BufferReader, target: str, fs: FileSystem | None):
 
 
 class LazyBuffer:
-    def __init__(self, packer: LazyCodec | None, fs: FileSystem | None):
+    def __init__(
+        self,
+        buffer_or_path: str | UPath | BufferWriter,
+        packer: LazyCodec | None,
+        fs: FileSystem | None,
+    ):
+        self._buffer_or_path: str | UPath | BufferWriter = buffer_or_path
         self._packer: LazyCodec = packer or MsgpackCodec()
         self._fs: FileSystem | None = fs or config.fs
 
         self._buffer: BufferWriter | TemporaryFile = None  # type: ignore
         self._header_start: int = 0
+        self._file_start: int = 0
 
-    def _finalize(self, packed_toc: bytes, toc_start: int):
-        self._buffer.write(packed_toc)
+    def _finalize(self, toc: dict):
+        toc_start: int = self._buffer.tell() - self._file_start
+        self._buffer.write(packed_toc := self._packer.encode(toc))
         self._buffer.seek(self._header_start)
         self._buffer.write(self._packer.encode(toc_start).rjust(10, b"\0"))
         self._buffer.write(self._packer.encode(len(packed_toc)).rjust(10, b"\0"))
@@ -112,13 +120,10 @@ class LazyWriter(LazyBuffer):
         :param fs: `FileSystem` object to be used for storing
         :param toc_cls: a `TOC` packer class
         """
-        super().__init__(packer, fs)
-
-        self._buffer_or_path: str | UPath | BufferWriter = buffer_or_path
+        super().__init__(buffer_or_path, packer, fs)
 
         self._toc_packer: TOC = None  # type: ignore
         self._toc_cls = toc_cls or TOC
-        self._file_start: int = 0
         self._no_more_writes: bool = False
 
     def __enter__(self):
@@ -178,9 +183,7 @@ class LazyWriter(LazyBuffer):
 
         self._no_more_writes = True
 
-        toc: dict = self._toc_packer.pack(obj)
-
-        self._finalize(self._packer.encode(toc), self._buffer.tell() - self._file_start)
+        self._finalize(self._toc_packer.pack(obj))
 
 
 class LazyCombiner(LazyBuffer):
@@ -202,13 +205,11 @@ class LazyCombiner(LazyBuffer):
         :param packer: packer object to be used for packing the object
         :param fs: `FileSystem` object to be used for storing
         """
-        super().__init__(packer, fs)
+        super().__init__(buffer_or_path, packer, fs)
 
-        self._buffer_or_path: str | UPath | BufferWriter = buffer_or_path
         self._mode: str = mode
 
         self._toc: dict | list = None  # type: ignore
-        self._file_start: int = 0
 
     def __enter__(self):
         if isinstance(self._buffer_or_path, str):
@@ -294,10 +295,7 @@ class LazyCombiner(LazyBuffer):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self._finalize(
-            self._packer.encode({"t": self._toc}),
-            self._buffer.tell() - self._file_start,
-        )
+        self._finalize({"t": self._toc})
 
         if isinstance(self._buffer_or_path, str):
             _upsert(self._buffer, self._buffer_or_path, self._fs)
@@ -307,9 +305,9 @@ class LazyCombiner(LazyBuffer):
 
     def write(self, obj: Generator, name: str | None = None) -> None:
         """
-        Write a number of objects to the file.
+        Write the object to the file.
 
-        :param obj: a generator of objects to be written to the file
+        :param obj: the object to be written to the file, the generator shall yield data
         :param name: a name to be assigned to the object, only required when combining in dict mode
         """
         if self._toc is None:

--- a/src/msglc/writer.py
+++ b/src/msglc/writer.py
@@ -58,7 +58,6 @@ class LazyBuffer:
     ):
         self._buffer_or_path: str | UPath | BufferWriter = buffer_or_path
         self._packer: LazyCodec = acquire_codec(packer)
-
         self._fs: FileSystem | None = fs or config.fs
 
         self._buffer: BufferWriter | TemporaryFile = None  # type: ignore

--- a/src/msglc/writer.py
+++ b/src/msglc/writer.py
@@ -20,9 +20,9 @@ from io import BufferedReader, BytesIO
 from tempfile import TemporaryFile
 from typing import TYPE_CHECKING
 
-from msgpack import Packer, packb, unpackb
 from upath import UPath
 
+from .codec import LazyCodec, MsgpackCodec
 from .config import (
     config,
     decrement_gc_counter,
@@ -49,7 +49,22 @@ def _upsert(source: BufferReader, target: str, fs: FileSystem | None):
             s3_file.write(chunk)
 
 
-class LazyWriter:
+class LazyBuffer:
+    def __init__(self, packer: LazyCodec | None, fs: FileSystem | None):
+        self._packer: LazyCodec = packer or MsgpackCodec()
+        self._fs: FileSystem | None = fs or config.fs
+
+        self._buffer: BufferWriter | TemporaryFile = None  # type: ignore
+        self._header_start: int = 0
+
+    def _finalize(self, packed_toc: bytes, toc_start: int):
+        self._buffer.write(packed_toc)
+        self._buffer.seek(self._header_start)
+        self._buffer.write(self._packer.encode(toc_start).rjust(10, b"\0"))
+        self._buffer.write(self._packer.encode(len(packed_toc)).rjust(10, b"\0"))
+
+
+class LazyWriter(LazyBuffer):
     magic: bytes = b"msglc-2024".rjust(max_magic_len, b"\0")
 
     @classmethod
@@ -63,14 +78,14 @@ class LazyWriter:
     def __init__(
         self,
         buffer_or_path: str | UPath | BufferWriter,
-        packer: Packer = None,
         *,
+        packer: LazyCodec | None = None,
         fs: FileSystem | None = None,
         toc_cls: type[TOC] | None = None,
     ):
         """
         It is possible to provide a custom packer object to be used for packing the object.
-        However, this packer must be compatible with the `msgpack` packer.
+        However, this packer must be implement `encode` and `decode` methods.
 
         The `buffer_or_path` can be
         1. a plain `str` pointing to a file on local filesystem, or a file on target filesystem if `fs` is provided,
@@ -97,14 +112,12 @@ class LazyWriter:
         :param fs: `FileSystem` object to be used for storing
         :param toc_cls: a `TOC` packer class
         """
-        self._buffer_or_path: str | UPath | BufferWriter = buffer_or_path
-        self._packer: Packer = packer or Packer()
-        self._fs: FileSystem | None = fs or config.fs
+        super().__init__(packer, fs)
 
-        self._buffer: BufferWriter | TemporaryFile = None  # type: ignore
+        self._buffer_or_path: str | UPath | BufferWriter = buffer_or_path
+
         self._toc_packer: TOC = None  # type: ignore
         self._toc_cls = toc_cls or TOC
-        self._header_start: int = 0
         self._file_start: int = 0
         self._no_more_writes: bool = False
 
@@ -166,21 +179,17 @@ class LazyWriter:
         self._no_more_writes = True
 
         toc: dict = self._toc_packer.pack(obj)
-        toc_start: int = self._buffer.tell() - self._file_start
-        packed_toc: bytes = self._packer.pack(toc)
 
-        self._buffer.write(packed_toc)
-        self._buffer.seek(self._header_start)
-        self._buffer.write(self._packer.pack(toc_start).rjust(10, b"\0"))
-        self._buffer.write(self._packer.pack(len(packed_toc)).rjust(10, b"\0"))
+        self._finalize(self._packer.encode(toc), self._buffer.tell() - self._file_start)
 
 
-class LazyCombiner:
+class LazyCombiner(LazyBuffer):
     def __init__(
         self,
         buffer_or_path: str | UPath | BufferWriter,
         *,
         mode: Literal["a", "w"] = "w",
+        packer: LazyCodec | None = None,
         fs: FileSystem | None = None,
     ):
         """
@@ -190,16 +199,15 @@ class LazyCombiner:
 
         :param buffer_or_path: target buffer or file path
         :param mode: mode of operation, 'w' for write and 'a' for append
+        :param packer: packer object to be used for packing the object
         :param fs: `FileSystem` object to be used for storing
         """
+        super().__init__(packer, fs)
+
         self._buffer_or_path: str | UPath | BufferWriter = buffer_or_path
         self._mode: str = mode
-        self._fs: FileSystem | None = fs or config.fs
-
-        self._buffer: BufferWriter | TemporaryFile = None  # type: ignore
 
         self._toc: dict | list = None  # type: ignore
-        self._header_start: int = 0
         self._file_start: int = 0
 
     def __enter__(self):
@@ -264,11 +272,11 @@ class LazyCombiner:
                     "Invalid file format, cannot append to the current file."
                 )
 
-            toc_start: int = unpackb(header[sep_a:sep_b].lstrip(b"\0"))
-            toc_size: int = unpackb(header[sep_b:sep_c].lstrip(b"\0"))
+            toc_start: int = self._packer.decode(header[sep_a:sep_b].lstrip(b"\0"))
+            toc_size: int = self._packer.decode(header[sep_b:sep_c].lstrip(b"\0"))
 
             self._buffer.seek(ini_position + sep_c + toc_start)
-            self._toc = unpackb(self._buffer.read(toc_size)).get("t", None)
+            self._toc = self._packer.decode(self._buffer.read(toc_size)).get("t", None)
 
             if isinstance(self._toc, list):
                 if any(not isinstance(i, int) for i in self._toc):
@@ -286,13 +294,10 @@ class LazyCombiner:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        toc_start: int = self._buffer.tell() - self._file_start
-        packed_toc: bytes = packb({"t": self._toc})
-
-        self._buffer.write(packed_toc)
-        self._buffer.seek(self._header_start)
-        self._buffer.write(packb(toc_start).rjust(10, b"\0"))
-        self._buffer.write(packb(len(packed_toc)).rjust(10, b"\0"))
+        self._finalize(
+            self._packer.encode({"t": self._toc}),
+            self._buffer.tell() - self._file_start,
+        )
 
         if isinstance(self._buffer_or_path, str):
             _upsert(self._buffer, self._buffer_or_path, self._fs)

--- a/src/msglc/writer.py
+++ b/src/msglc/writer.py
@@ -16,14 +16,13 @@
 from __future__ import annotations
 
 import os.path
-from inspect import isclass
 from io import BufferedReader, BytesIO
 from tempfile import TemporaryFile
 from typing import TYPE_CHECKING
 
 from upath import UPath
 
-from .codec import LazyCodec, MsgspecCodec
+from .codec import LazyCodec, acquire_codec
 from .config import (
     config,
     decrement_gc_counter,
@@ -58,15 +57,7 @@ class LazyBuffer:
         fs: FileSystem | None,
     ):
         self._buffer_or_path: str | UPath | BufferWriter = buffer_or_path
-        self._packer: LazyCodec
-        if isinstance(packer, LazyCodec):
-            self._packer = packer
-        elif isclass(packer) and issubclass(packer, LazyCodec):
-            self._packer = packer()
-        elif packer is None:
-            self._packer = MsgspecCodec()
-        else:
-            raise TypeError("Need a valid packer.")
+        self._packer: LazyCodec = acquire_codec(packer)
 
         self._fs: FileSystem | None = fs or config.fs
 

--- a/tests/generate.py
+++ b/tests/generate.py
@@ -20,9 +20,9 @@ import string
 import msgpack  # type: ignore
 
 from msglc import dump
+from msglc.codec import LazyCodec
 from msglc.config import configure
 from msglc.reader import LazyDict, LazyList, LazyReader, LazyStats
-from msglc.unpacker import Unpacker
 
 
 def generate_token():
@@ -124,7 +124,7 @@ def generate(*, depth=6, width=11, threshold=23):
         configure_and_dump(archive, step)
 
 
-def compare(mode, size: int = 13, total: int = 5, unpacker: Unpacker = None):
+def compare(mode, size: int = 13, total: int = 5, unpacker: LazyCodec = None):
     accumulator: int = 0
 
     with open("path.txt") as f:

--- a/tests/h5/read.py
+++ b/tests/h5/read.py
@@ -6,8 +6,8 @@ import h5py
 import matplotlib.pyplot as plt
 from timer import get_color, timeit
 
+from msglc.codec import MsgspecCodec
 from msglc.reader import LazyReader
-from msglc.unpacker import MsgspecUnpacker
 
 repeat = 1000
 
@@ -22,7 +22,7 @@ except ImportError:
 
 @timeit
 def read_msg(file: str):
-    with LazyReader(file, unpacker=MsgspecUnpacker, cached=False) as reader:
+    with LazyReader(file, unpacker=MsgspecCodec, cached=False) as reader:
         for _ in range(repeat):
             reader[random.randint(0, 4999)][random.randint(0, 4999)]
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -131,7 +131,7 @@ def prepare(tmpdir_factory):
 @pytest.mark.parametrize("total", [0, 1, 2, 3, 4])
 @pytest.mark.parametrize(
     "unpacker",
-    [MsgpackCodec(), MsgspecCodec(), OrmsgpackCodec()],
+    [MsgpackCodec(), MsgspecCodec(), OrmsgpackCodec],
     ids=["vanilla", "msgspec", "ormsgpack"],
 )
 def test_matrix(prepare, benchmark, size, total, unpacker):

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -26,8 +26,8 @@ from generate import (
 )
 
 from msglc import config, dump
+from msglc.codec import MsgpackCodec, MsgspecCodec
 from msglc.reader import LazyReader, LazyStats
-from msglc.unpacker import MsgpackUnpacker, MsgspecUnpacker
 
 
 @pytest.mark.parametrize("backend", ["python", "rust"])
@@ -130,7 +130,7 @@ def prepare(tmpdir_factory):
 @pytest.mark.parametrize("size", [x for x in range(13, 25)])
 @pytest.mark.parametrize("total", [0, 1, 2, 3, 4])
 @pytest.mark.parametrize(
-    "unpacker", [MsgpackUnpacker(), MsgspecUnpacker()], ids=["vanilla", "msgspec"]
+    "unpacker", [MsgpackCodec(), MsgspecCodec()], ids=["vanilla", "msgspec"]
 )
 def test_matrix(prepare, benchmark, size, total, unpacker):
     with prepare.as_cwd():

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -26,7 +26,7 @@ from generate import (
 )
 
 from msglc import config, dump
-from msglc.codec import MsgpackCodec, MsgspecCodec
+from msglc.codec import MsgpackCodec, MsgspecCodec, OrmsgpackCodec
 from msglc.reader import LazyReader, LazyStats
 
 
@@ -130,7 +130,9 @@ def prepare(tmpdir_factory):
 @pytest.mark.parametrize("size", [x for x in range(13, 25)])
 @pytest.mark.parametrize("total", [0, 1, 2, 3, 4])
 @pytest.mark.parametrize(
-    "unpacker", [MsgpackCodec(), MsgspecCodec()], ids=["vanilla", "msgspec"]
+    "unpacker",
+    [MsgpackCodec(), MsgspecCodec(), OrmsgpackCodec()],
+    ids=["vanilla", "msgspec", "ormsgpack"],
 )
 def test_matrix(prepare, benchmark, size, total, unpacker):
     with prepare.as_cwd():

--- a/tests/test_msglc.py
+++ b/tests/test_msglc.py
@@ -97,9 +97,9 @@ def test_msglc(
             for x in list_container:
                 assert x in ["GML", "XML"]
             assert set(list_container) == {"GML", "XML"}
-            assert unpackb(reader.msgpack_raw_data(chunked=False)) == reader.to_obj()
+            assert unpackb(reader.protocol_raw_data(chunked=False)) == reader.to_obj()
             assert (
-                unpackb(b"".join(reader.msgpack_raw_data(chunked=True)))
+                unpackb(b"".join(reader.protocol_raw_data(chunked=True)))
                 == reader.to_obj()
             )
 

--- a/tests/test_msglc.py
+++ b/tests/test_msglc.py
@@ -25,6 +25,7 @@ from msgpack import unpackb
 from upath import UPath
 
 from msglc import FileInfo, LazyWriter, append, combine, dump
+from msglc.codec import MsgpackCodec, MsgspecCodec, OrmsgpackCodec
 from msglc.config import config, configure, decrement_gc_counter, increment_gc_counter
 from msglc.reader import LazyReader, LazyStats, async_to_obj
 from msglc.utility import MockIO
@@ -37,8 +38,13 @@ from msglc.utility import MockIO
 @pytest.mark.parametrize("size", [0, 8192])
 @pytest.mark.parametrize("cached", [True, False])
 @pytest.mark.parametrize("fs_cls", [None, ZipFileSystem])
+@pytest.mark.parametrize(
+    "packer",
+    [MsgpackCodec(), MsgspecCodec(), OrmsgpackCodec()],
+    ids=["vanilla", "msgspec", "ormsgpack"],
+)
 def test_msglc(
-    monkeypatch, tmpdir, json_before, json_after, target, size, cached, fs_cls
+    monkeypatch, tmpdir, json_before, json_after, target, size, cached, fs_cls, packer
 ):
     monkeypatch.setattr(config, "small_obj_optimization_threshold", size)
 
@@ -47,7 +53,7 @@ def test_msglc(
             target.seek(0)
 
         fs = fs_cls("archive.zip", "w") if fs_cls else None
-        with LazyWriter(target, fs=fs) as writer:
+        with LazyWriter(target, packer=packer, fs=fs) as writer:
             writer.write(json_before)
             with pytest.raises(ValueError):
                 writer.write(json_before)


### PR DESCRIPTION
Refactor the unpacking mechanism by renaming `unpacker` to `codec` for consistency. Introduce the `LazyCodec` class and its subclasses, implementing the `encode` and `stream_decode` methods to enhance data handling. Update relevant references throughout the codebase to reflect these changes.