### PR TITLE
Enhance LazyReader and documentation for combined archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-from msglc.codec import CBORCodec
-
 # msglc --- (de)serialize json objects with lazy/partial loading containers using msgpack or cbor
 
 [![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/TLCFEM/msglc)

--- a/docs/example.md
+++ b/docs/example.md
@@ -88,6 +88,31 @@ with LazyReader("combined.msg") as reader:
     assert reader['1/101'] == 101.0  # also reader[1][101]
 ```
 
+It is possible to combine files with different formats together.
+
+```python
+from msglc import dump, combine, FileInfo
+from msglc.codec import CBORCodec, MsgspecCodec
+from msglc.reader import LazyReader
+
+# this file uses cbor format
+dump("dict.cbor", {str(v): v for v in range(1000)}, backend='rust', packer=CBORCodec)
+# this file uses msgpack format
+dump("list.msg", [float(v) for v in range(1000)], backend='rust')
+
+# two files are combined together,
+# the additional metadata generated for the combined file uses msgpack format
+# but the underlying data of each file is not changed
+combine("combined.msg", [FileInfo("dict.cbor"), FileInfo("list.msg")], packer=MsgspecCodec)
+
+# the combined file uses a list layout
+# [ {'1':1,'2':2,...}, [1.0,2.0,3.0,...] ]
+# so one can read it as follows, details in coming section
+with LazyReader("combined.msg") as reader:
+    assert reader['0/101'] == 101  # also reader[0][101]
+    assert reader['1/101'] == 101.0  # also reader[1][101]
+```
+
 ## Deserialization
 
 Use `LazyReader` to read a file.
@@ -206,9 +231,9 @@ class DictStream(Mapping):
 ```
 
 !!! warning "length requirement"
-    Only two things will be invoked: `len()` and `.items()`.
-    Thus, `__len__(self)` and `items(self)` must be properly implemented.
-    If the length is **not** known in advance, streaming data is not feasible.
+Only two things will be invoked: `len()` and `.items()`.
+Thus, `__len__(self)` and `items(self)` must be properly implemented.
+If the length is **not** known in advance, streaming data is not feasible.
 
 With the above, one can do the following.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [project]
-version = "260319"
+version = "000000"
 name = "msglc"
 description = "binary json representation (msgpack or cbor) with lazy/partial loading containers"
 readme = "README.md"

--- a/src/msglc/reader.py
+++ b/src/msglc/reader.py
@@ -171,7 +171,7 @@ class LazyItem:
         # this is used in combined archives
         if isinstance(toc, int):
             self._buffer.seek(toc + self._offset)
-            return LazyReader(self._buffer, **params)
+            return LazyReader(self._buffer, **params, from_combined=True)
 
         if (child_toc := toc.get("t", None)) is None:
             # {"p": [start_pos, end_pos]}
@@ -504,6 +504,7 @@ class LazyReader(LazyItem):
         cached: bool = True,
         unpacker: type[LazyCodec] | LazyCodec | None = None,
         fs: FileSystem | None = None,
+        **kwargs,
     ):
         """
         It is possible to use a customized unpacker.
@@ -571,9 +572,11 @@ class LazyReader(LazyItem):
         if unpacker is None:
             unpacker = MsgspecCodec if header[sep_a] == 0 else CBORCodec
         elif (unpacker.protocol == "msgpack") != (header[sep_a] == 0):
-            raise ValueError(
-                f"The given unpacker {unpacker} does not match file protocol."
-            )
+            if not kwargs.get("from_combined", False):
+                raise ValueError(
+                    f"The given unpacker {unpacker} does not match file protocol."
+                )
+            unpacker = MsgspecCodec if header[sep_a] == 0 else CBORCodec
 
         super().__init__(
             buffer,

--- a/tests/test_msglc.py
+++ b/tests/test_msglc.py
@@ -389,7 +389,7 @@ def test_combine_archives_append(tmpdir, json_after, target):
     with tmpdir.as_cwd():
         with LazyWriter("test_list.msg") as writer:
             writer.write([x for x in range(30)])
-        with LazyWriter("test_dict.msg") as writer:
+        with LazyWriter("test_dict.msg", packer=CBORCodec) as writer:
             writer.write(json_after)
 
         combine(target, [FileInfo("test_dict.msg")])


### PR DESCRIPTION
Improve LazyReader to support combined archives and enhance unpacker validation. Update documentation with examples for combining files of different formats. Remove unused import and bump version in pyproject.toml.